### PR TITLE
Resource path is relative to location.pathname

### DIFF
--- a/js/rubiks.js
+++ b/js/rubiks.js
@@ -541,7 +541,11 @@ function scramble() {
 
 $(document).ready(function() {
     $canvas = $('#glcanvas');
-    $.get('/models/rubiks-cube.json', function(data) {
+
+    const pathname = location.pathname;
+    const base = pathname.substring(0, pathname.lastIndexOf('/'));
+
+    $.get(`${base}/models/rubiks-cube.json`, function(data) {
         start(data[0]);
         $canvas.bind('contextmenu', function(e) { return false; });
         $canvas.mousedown(startRotate);


### PR DESCRIPTION
This fixes the 404 on the project's GitHub page.

The page URL is http://tinnywang.github.io/rubiks-cube/, so the JSON file is at `/rubiks-cube/models/rubiks-cube.json` and not `models/rubiks-cube.json`.