### PR TITLE
Cube layers rotate with left mouse

### DIFF
--- a/js/bounding-box.js
+++ b/js/bounding-box.js
@@ -101,9 +101,9 @@ function Plane(p0, p1, p2) {
     this.normal = glMatrix.vec3.cross(glMatrix.vec3.create(), this.p01, this.p02);
 
     this.randomPoint = function() {
-        return glMatrix.vec3.add( glMatrix.vec3.create(),
-            glMatrix.vec3.scale(glMatrix.vec3.create(), this.p01, Math.random()),
-            glMatrix.vec3.scale(glMatrix.vec3.create(), this.p02, Math.random()),
-        )
+        const point = glMatrix.vec3.copy(glMatrix.vec3.create(), p0);
+        glMatrix.vec3.add(point, point, glMatrix.vec3.scale(glMatrix.vec3.create(), this.p01, Math.random()));
+        glMatrix.vec3.add(point, point, glMatrix.vec3.scale(glMatrix.vec3.create(), this.p02, Math.random()));
+        return point;
     }
 }

--- a/js/rubiks.js
+++ b/js/rubiks.js
@@ -166,10 +166,26 @@ function RubiksCube(data) {
      * Rotates this.rotatedCubes around this.rotationAxis by DEGREES.
      */
     this.rotateLayer = function() {
+        // A rotation has been completed. Stop rotating.
         if (this.rotationAngle === 90) {
             this.rotationAngle = 0;
+            initIntersection = null;
+            newIntersection = null;
+            this.rotationAxis = null;
+            this.rotatedCubes = null;
             isRotating = false;
             this.scramble();
+            return;
+        }
+
+        // Set this.rotationAxis and this.rotatedCubes before starting a rotation.
+        if (this.rotationAngle === 0)  {
+            rubiksCube.setRotationAxis(initIntersection, newIntersection);
+            rubiksCube.setRotatedCubes(initIntersection, newIntersection, this.rotationAxis);
+            isRotating = !!(this.rotatedCubes && this.rotationAxis);
+        }
+
+        if (!isRotating) {
             return;
         }
 
@@ -392,9 +408,7 @@ function initShaders() {
 }
 
 function drawScene() {
-    if (isRotating) {
-        rubiksCube.rotateLayer();
-    }
+    rubiksCube.rotateLayer();
 
     rubiksCube.draw();
     requestAnimationFrame(drawScene);
@@ -438,9 +452,11 @@ function rotate(event) {
     if (leftMouseDown) {
         newIntersection = rubiksCube.select(event.pageX, event.pageY);
         if (newIntersection) {
+            /*
             rubiksCube.setRotationAxis(initIntersection, newIntersection);
             rubiksCube.setRotatedCubes(initIntersection, newIntersection, rubiksCube.rotationAxis);
             isRotating = !!(rubiksCube.rotatedCubes && rubiksCube.rotationAxis);
+            */
         }
     } else if (rightMouseDown) {
         xNewRight = event.pageX;

--- a/js/rubiks.js
+++ b/js/rubiks.js
@@ -162,6 +162,23 @@ function RubiksCube(data) {
         return lower < value && value < upper;
     }
 
+    // TODO: use angle between movement and direction to determine if movement is valid?
+    // Or keep using dot product?
+    rotationDegrees = function(initIntersection, newIntersection, axis) {
+        if (!initIntersection || !newIntersection) {
+            return 0;
+        }
+
+        const direction = glMatrix.vec3.cross(glMatrix.vec3.create(), axis, initIntersection.normal);
+        const movement = glMatrix.vec3.subtract(glMatrix.vec3.create(), newIntersection.point, initIntersection.point);
+        const dotProduct = glMatrix.vec3.dot(direction, glMatrix.vec3.normalize(glMatrix.vec3.create(), movement));
+        if (dotProduct >= 0.9) {
+            return dotProduct * glMatrix.vec3.dot(direction, movement);
+        } else {
+            return 0;
+        }
+    }
+
     /*
      * Rotates this.rotatedCubes around this.rotationAxis by DEGREES.
      */
@@ -193,16 +210,8 @@ function RubiksCube(data) {
         let degrees = 0;
         if (this.rotationAngle + SNAP_DEGREES > 90) {
             degrees = 90 - this.rotationAngle;
-        } else if (newIntersection && initIntersection) {
-            degrees = glMatrix.vec3.length(
-                glMatrix.vec3.subtract(
-                    glMatrix.vec3.create(),
-                    newIntersection.point,
-                    initIntersection.point,
-                ),
-            );
         } else {
-            degrees = SNAP_DEGREES;
+            degrees = rotationDegrees(initIntersection, newIntersection, this.rotationAxis) || SNAP_DEGREES;
         }
         this.rotationAngle += degrees;
 

--- a/js/rubiks.js
+++ b/js/rubiks.js
@@ -103,7 +103,9 @@ function RubiksCube(data) {
     }
 
     this.isRotating = function() {
-        return this.rotation.cubes !== null && this.rotation.axis !== null
+        return this.rotation.cubes !== null &&
+            this.rotation.axis !== null &&
+            this.rotation.speed !== 0;
     }
 
     this.init();
@@ -243,9 +245,8 @@ function RubiksCube(data) {
 
         // A rotation has been completed. Stop rotating.
         if (Math.abs(this.rotation.angle) === 90) {
-            window.setTimeout(() => {
-                this.initRotation();
-            }, DEBOUNCE_TIMEOUT);
+            this.initRotation();
+            this.endRotate();
             return;
         }
 

--- a/js/rubiks.js
+++ b/js/rubiks.js
@@ -26,17 +26,11 @@ var shaderProgram;
 
 var leftMouseDown = false;
 var rightMouseDown = false;
-var xInitRight;
-var yInitRight;
-var xNewRight;
-var yNewRight;
 var isScrambling = false;
 
 var modelViewMatrix = glMatrix.mat4.create();
 var projectionMatrix = glMatrix.mat4.create();
 var rotationMatrix = glMatrix.mat4.create();
-
-var startTime = 0;
 
 function RubiksCube(data) {
     this.data = data;
@@ -460,14 +454,19 @@ function initShaders() {
 
 // timestamp is a DOMHighResTimeStamp.
 // See https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame.
-function drawScene(timestamp) {
-    const timeDelta = timestamp - startTime;
+function drawScene() {
+    let startTime = 0;
 
-    rubiksCube.draw();
-    rubiksCube.rotate(timeDelta);
-    requestAnimationFrame(drawScene);
+    const animate = function(timestamp) {
+        const timeDelta = timestamp - startTime;
 
-    startTime = timestamp;
+        rubiksCube.draw();
+        rubiksCube.rotate(timeDelta);
+        requestAnimationFrame(animate);
+
+        startTime = timestamp;
+    }
+    return animate;
 }
 
 function start(data) {
@@ -484,7 +483,7 @@ function start(data) {
 
         rubiksCube = new RubiksCube(data);
         perspectiveView();
-        drawScene(performance.now());
+        drawScene()(performance.now());
     }
 }
 
@@ -504,29 +503,6 @@ function setMatrixUniforms() {
     gl.uniformMatrix3fv(normalMatrixUniform, false, normalMatrix3);
 }
 
-/*
-function rotate(event) {
-    if (leftMouseDown) {
-        newIntersection = rubiksCube.select(event.pageX, event.pageY);
-        if (newIntersection) {
-            // rubiksCube.setRotationAxis(initIntersection, newIntersection);
-            // rubiksCube.setRotatedCubes(initIntersection, newIntersection, rubiksCube.rotation.axis);
-            // isRotating = !!(rubiksCube.rotation.cubes && rubiksCube.rotation.axis);
-        }
-    } else if (rightMouseDown) {
-        xNewRight = event.pageX;
-        yNewRight = event.pageY;
-        const delta_x = (xNewRight - xInitRight) / 50;
-        const delta_y = (yNewRight - yInitRight) / 50;
-        const axis = [delta_y, delta_x, 0];
-        const degrees = Math.sqrt(delta_x * delta_x + delta_y * delta_y);
-        const newRotationMatrix = glMatrix.mat4.create();
-        glMatrix.mat4.fromRotation(newRotationMatrix, glMatrix.glMatrix.toRadian(degrees), axis);
-        glMatrix.mat4.multiply(rotationMatrix, newRotationMatrix, rotationMatrix);
-    }
-}
-*/
-
 function startRotate(event) {
     // The Rubik's cube can be rotated with right mouse while it's being scrambled, but
     // individual layers of the cube cannot be rotated with left mouse.
@@ -535,8 +511,6 @@ function startRotate(event) {
         rubiksCube.startRotate(event.pageX, event.pageY, event.timeStamp);
     } else if (isRightMouse(event)) {
         rightMouseDown = true;
-        xInitRight = event.pageX;
-        yInitRight = event.pageY;
     }
 }
 


### PR DESCRIPTION
Change the cube layer rotation behavior so that the layer rotates as the mouse moves. The current implementation does not rotate the layer until after left mouse has been released, so the rotation animation is delayed.

~This PR breaks scrambling and right mouse rotations and should not be merged into `master` yet.~

https://github.com/tinnywang/rubiks-cube/pull/10 fixes right mouse rotations.
https://github.com/tinnywang/rubiks-cube/pull/11 fixes scrambling.